### PR TITLE
refactor: 토큰의 검증 메서드명 수정

### DIFF
--- a/src/main/java/com/example/realworld/jwt/JwtTokenParser.java
+++ b/src/main/java/com/example/realworld/jwt/JwtTokenParser.java
@@ -20,7 +20,7 @@ public class JwtTokenParser implements TokenParser {
     }
 
     public String findEmailByToken(String token) {
-        verifyingTheAuthenticationHeader(token);
+        verifyToken(token);
         Claims claims = parsedToken(token);
         return (String) claims.get("email");
     }
@@ -32,8 +32,8 @@ public class JwtTokenParser implements TokenParser {
                 .getBody();
     }
 
-    private void verifyingTheAuthenticationHeader(String header) {
-        if (isNull(header)) {
+    private void verifyToken(String token) {
+        if (isNull(token)) {
             throw new NotValidTokenException(ErrorCode.NOT_VALID_TOKEN);
         }
     }


### PR DESCRIPTION
변경 사유 : 헤더를 검증하는 것이 아닌 토큰의 값이 null인지 아닌지 검증하는 메서드이기 때문이다.