### PR TITLE
feat: 유저 팔로우 기능 및 테스트 구현

### DIFF
--- a/src/main/java/com/example/realworld/domain/user/exception/DuplicatedFollowingUserException.java
+++ b/src/main/java/com/example/realworld/domain/user/exception/DuplicatedFollowingUserException.java
@@ -1,0 +1,12 @@
+package com.example.realworld.domain.user.exception;
+
+import com.example.realworld.web.exception.BusinessException;
+import com.example.realworld.web.exception.ErrorCode;
+
+public class DuplicatedFollowingUserException extends BusinessException {
+
+    public DuplicatedFollowingUserException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+}

--- a/src/main/java/com/example/realworld/domain/user/model/User.java
+++ b/src/main/java/com/example/realworld/domain/user/model/User.java
@@ -1,5 +1,9 @@
 package com.example.realworld.domain.user.model;
 
+import com.example.realworld.domain.user.exception.DuplicatedFollowingUserException;
+import com.example.realworld.web.exception.ErrorCode;
+import java.util.Collection;
+import java.util.Set;
 import lombok.Builder;
 import lombok.ToString;
 
@@ -12,11 +16,14 @@ public class User {
 
     private String image;
 
+    private final Set<String> followingEmails;
+
     @Builder
-    private User(UserAccountInfo userAccountInfo, String bio, String image) {
+    private User(UserAccountInfo userAccountInfo, String bio, String image, Set<String> followingEmails) {
         this.userAccountInfo = userAccountInfo;
         this.bio = bio;
         this.image = image;
+        this.followingEmails = followingEmails;
     }
 
     public UserAccountInfo accountInfo() {
@@ -52,6 +59,22 @@ public class User {
 
     public void changeEncodedPassword(String password) {
         userAccountInfo.changeEncodedPassword(password);
+    }
+
+    public void follow(User followedUser) {
+        verifyDuplicateFollowEmail(followedUser);
+        followingEmails.add(followedUser.email());
+    }
+
+    public Collection<String> followingEmails() {
+        return followingEmails.stream()
+                .toList();
+    }
+
+    private void verifyDuplicateFollowEmail(User followedUser) {
+        if (followingEmails.contains(followedUser.email())) {
+            throw new DuplicatedFollowingUserException(ErrorCode.DuplicatedFollowingUser);
+        }
     }
 
 }

--- a/src/main/java/com/example/realworld/web/exception/ErrorCode.java
+++ b/src/main/java/com/example/realworld/web/exception/ErrorCode.java
@@ -14,10 +14,14 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     NO_SUCH_USER_ELEMENT("회원을 조회할 수 없습니다.", HttpStatus.NOT_FOUND),
+
     NOT_VALID_TOKEN("유효한 토큰이 아닙니다.", HttpStatus.FORBIDDEN),
-    NOT_FOUND_REQUESTS("", HttpStatus.NOT_FOUND),
+
     DUPLICATED_EMAIL("이미 존재하는 이메일입니다.", HttpStatus.UNPROCESSABLE_ENTITY),
-    Not_Valid_Login("아이디 또는 비밀번호가 틀렸습니다.", HttpStatus.NOT_FOUND);
+
+    Not_Valid_Login("아이디 또는 비밀번호가 틀렸습니다.", HttpStatus.NOT_FOUND),
+
+    DuplicatedFollowingUser("이미 팔로우한 유저입니다.", HttpStatus.UNPROCESSABLE_ENTITY);
 
     private final String message;
     private final HttpStatus status;

--- a/src/test/java/com/example/realworld/domain/user/UserTests.java
+++ b/src/test/java/com/example/realworld/domain/user/UserTests.java
@@ -1,11 +1,16 @@
 package com.example.realworld.domain.user;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
+import com.example.realworld.domain.user.exception.DuplicatedFollowingUserException;
 import com.example.realworld.domain.user.model.User;
 import com.example.realworld.domain.user.model.UserAccountInfo;
+import com.example.realworld.web.exception.ErrorCode;
+import java.util.HashSet;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class UserTests {
@@ -44,6 +49,66 @@ public class UserTests {
                 () -> assertThat(updatedUser.image()).isEqualTo(newUser.image()),
                 () -> assertThat(updatedUser.email()).isEqualTo(newUser.email())
         );
+    }
+
+    @Test
+    @DisplayName("팔로우 하기")
+    void followingTest() {
+        // given
+        User user = getUser();
+        User followedUser = getAnotherUser();
+
+        // when
+        user.follow(followedUser);
+
+        // then
+        assertThat(user.followingEmails()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("이미 팔로우한 유저를 또 팔로우할 때 예외 발생")
+    void followingExceptionTest() {
+        // given
+        User user = getUser();
+        User followedUser = getAnotherUser();
+
+        // when
+        user.follow(followedUser);
+
+        // then
+        assertThatThrownBy(() -> user.follow(followedUser))
+                .isInstanceOf(DuplicatedFollowingUserException.class)
+                .hasMessage(ErrorCode.DuplicatedFollowingUser.message());
+    }
+
+    private User getUser() {
+        UserAccountInfo accountInfo = UserAccountInfo.builder()
+                .username("name")
+                .email("abc@naver.com")
+                .password("password")
+                .build();
+
+        return User.builder()
+                .userAccountInfo(accountInfo)
+                .bio("I like an apple")
+                .image("www.naver.com")
+                .followingEmails(new HashSet<>())
+                .build();
+    }
+
+    private User getAnotherUser() {
+        UserAccountInfo newAccountInfo = UserAccountInfo.builder()
+                .username("name2")
+                .email("email@naver.com")
+                .password("password2")
+                .build();
+
+        return User.builder()
+                .userAccountInfo(newAccountInfo)
+                .bio("I like a banana")
+                .image("www.google.com")
+                .followingEmails(new HashSet<>())
+                .build();
     }
 
 }


### PR DESCRIPTION
유저 팔로우 기능 구현
- 팔로우시 유저 내부에 팔로우 리스트인 `followingEmails` 에 팔로우 한 유저 아이디를 추가
- 중복 방지를 위해서 팔로우 리스트를 `Set` 타입으로 지정

유저 팔로우 예외 발생 상황
- 이미 팔로우한 유저를 또 다시 팔로우할 시 `DuplicatedFollowingUserException` 예외 발생
